### PR TITLE
fix: nil check before writing location to EXIF

### DIFF
--- a/ios/ExifReader.swift
+++ b/ios/ExifReader.swift
@@ -236,7 +236,12 @@ class ExifReader: NSObject {
 
     func writeLocationForPHAsset(uri: String, location: Dictionary<String, Any>, resolve:@escaping
         RCTPromiseResolveBlock,reject:@escaping RCTPromiseRejectBlock) -> Void {
-        var response:Dictionary<String, Any>?
+
+        // If we didn't receive the location, maybe b/c we don't have
+        // permission, just bail
+        if (!location.keys.contains("latitude")) {
+            return;
+        }
 
         // Update the PHAsset with the new photo data
         let options = PHContentEditingInputRequestOptions()


### PR DESCRIPTION
Fixes a crash in which location was not available due to lack of permissions. Not entirely sure this is the best approach. We could also throw an error when a user tries to write location data but there isn't any. This just gives up silently.